### PR TITLE
Updated MCP file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+/.idea

--- a/nlip_soln/mcp/mcp.py
+++ b/nlip_soln/mcp/mcp.py
@@ -1,6 +1,7 @@
 from multiprocessing import get_logger
 import os
 
+from nlip_sdk.nlip import NLIP_Factory
 from nlip_server import server
 from nlip_sdk import nlip
 
@@ -38,15 +39,15 @@ class ChatSession(server.NLIP_Session):
             await self.client.cleanup()
 
     async def execute(
-        self, msg: nlip.NLIP_Message | nlip.NLIP_BasicMessage
-    ) -> nlip.NLIP_Message | nlip.NLIP_BasicMessage:
+        self, msg: nlip.NLIP_Message
+    ) -> nlip.NLIP_Message:
         logger = self.get_logger()
-        text = nlip.nlip_extract_text(msg)
+        text = msg.extract_text()
 
         try:
             response = await self.client.process_query(text)
             logger.info(f"Response : {response}")
-            return nlip.nlip_encode_text(response)
+            return NLIP_Factory.create_text(response)
         except Exception as e:
             logger.error(f"Exception {e}")
             return None


### PR DESCRIPTION
Updated MCP files to remove references that no longer exist

1) Swapped out `nlip.nlip_extract_text(msg`) with `msg.extract_text()`
2) Swapped out `nlip.nlip_encode_text(response)` with `NLIP_Factory.create_text(response)`
3) Dropped the NLIP_BasicMessage union from the execute() method

Notes:
1) While MCP runs fine locally (I have tested with my NLIP Client), I'm not sure what was the original purpose of the NLIP_BasicMessage union. I would suggest it be double checked.
2) I added /idea to .gitignore